### PR TITLE
One more fix for the maboss containers

### DIFF
--- a/Resources/images/maboss.singularity
+++ b/Resources/images/maboss.singularity
@@ -7,9 +7,11 @@ Stage: build
 
 %post
     apt-get update -y
-    DEBIAN_FRONTEND=noninteractive apt-get install -yq r-base default-jre default-jdk git flex bison python-is-python3 pip wget
-    (cd /usr/local; mkdir scm; cd scm; git clone https://github.com/sysbio-curie/MaBoSS-env-2.0.git -b v2.4.1; cd MaBoSS-env-2.0/engine/src; make && make install)
-    (cd /usr/local/bin; ln -s /usr/local/scm/MaBoSS-env-2.0/engine/pub/* .)
+    DEBIAN_FRONTEND=noninteractive apt-get install -yq r-base default-jre default-jdk git flex bison python-is-python3 pip wget unzip
+    pip install maboss seaborn cmaboss==1.0.0b17
+    wget https://github.com/sysbio-curie/MaBoSS-env-2.0/releases/download/v2.4.1/MaBoSS-linux64.zip
+    unzip -o MaBoSS-linux64.zip -d /usr/local/bin/
+    
     mkdir /usr/local/jar
     wget https://b2drop.bsc.es/index.php/s/SRWPNAkKL73oaRw/download -O /usr/local/jar/BiNoM.jar
     wget https://github.com/auranic/VDAOEngine/raw/master/jar/VDAOEngine.jar -O /usr/local/jar/VDAOEngine.jar

--- a/Resources/oci-containers/maboss/requirements.txt
+++ b/Resources/oci-containers/maboss/requirements.txt
@@ -1,2 +1,3 @@
 maboss
 seaborn
+cmaboss==1.0.0b17

--- a/Resources/oci-containers/physicell_covid19/Dockerfile
+++ b/Resources/oci-containers/physicell_covid19/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get --quiet update && \
         wget \
         unzip \
         python3 \
-        python3-dev && \
+        python3-dev \
+        python3-pip && \
     rm -rf /var/lib/apt/lists/* && \
     ln -sf /usr/bin/python3 /usr/bin/python
 
@@ -30,3 +31,5 @@ RUN git clone --branch v6 --single-branch https://github.com/vincent-noel/COVID1
     rm -rf /usr/local/src/covid19/.git && \
     (cd /usr/local/src/covid19/PhysiCell && make ;) && \
     ln -sf /usr/local/src/covid19/PhysiCell/COVID19 /usr/local/bin/COVID19
+    
+RUN pip install pandas numpy scipy matplotlib seaborn

--- a/Resources/oci-containers/print_results/requirements-freeze.txt
+++ b/Resources/oci-containers/print_results/requirements-freeze.txt
@@ -3,6 +3,7 @@ seaborn==0.12.2
 matplotlib==3.6.3
 pandas==1.5.3
 numpy==1.24.2
+pyyaml==6.0.1
 
 # secondary
 contourpy==1.0.7

--- a/Resources/oci-containers/print_results/requirements.txt
+++ b/Resources/oci-containers/print_results/requirements.txt
@@ -2,3 +2,4 @@ seaborn
 matplotlib
 pandas
 numpy
+pyyaml


### PR DESCRIPTION
One quick fix for the maboss containers : 
- Fix the singularity container, which was missing the python libraries. 
- Pinned down the maboss C bindings to version 1.0.0b17, as the 1.0.0b18 introduced a bug. 